### PR TITLE
System logger is presented with a new abstract interface now.

### DIFF
--- a/include/cocaine/framework/basic_application.hpp
+++ b/include/cocaine/framework/basic_application.hpp
@@ -1,7 +1,7 @@
 #ifndef COCAINE_FRAMEWORK_BASIC_APPLICATION_HPP
 #define COCAINE_FRAMEWORK_BASIC_APPLICATION_HPP
 
-#include <cocaine/framework/service.hpp>
+#include <cocaine/framework/service_manager.hpp>
 
 #include <cocaine/framework/upstream.hpp>
 

--- a/include/cocaine/framework/logging.hpp
+++ b/include/cocaine/framework/logging.hpp
@@ -16,4 +16,36 @@
 #define COCAINE_LOG_ERROR(_log_, ...) \
     COCAINE_LOG(_log_, ::cocaine::logging::error, __VA_ARGS__)
 
+namespace cocaine { namespace framework {
+
+class logger_t
+{
+public:
+    virtual
+    ~logger_t() {
+        // pass
+    }
+
+
+    virtual
+    void
+    emit(cocaine::logging::priorities priority,
+         const std::string& message) = 0;
+
+    template<typename... Args>
+    void
+    emit(cocaine::logging::priorities priority,
+         const std::string& format,
+         const Args&... args)
+    {
+        emit(priority, cocaine::format(format, args...));
+    }
+
+    virtual
+    cocaine::logging::priorities
+    verbosity() const = 0;
+};
+
+}} // namespace cocaine::framework
+
 #endif // COCAINE_FRAMEWORK_LOGGING_HPP

--- a/include/cocaine/framework/service_manager.hpp
+++ b/include/cocaine/framework/service_manager.hpp
@@ -1,0 +1,55 @@
+#ifndef COCAINE_FRAMEWORK_SERVICE_MANAGER_HPP
+#define COCAINE_FRAMEWORK_SERVICE_MANAGER_HPP
+
+#include <cocaine/framework/service.hpp>
+#include <cocaine/framework/services/logger.hpp>
+
+namespace cocaine { namespace framework {
+
+class service_manager_t {
+    COCAINE_DECLARE_NONCOPYABLE(service_manager_t)
+
+    typedef cocaine::io::tcp::endpoint endpoint_t;
+
+public:
+    service_manager_t(cocaine::io::reactor_t& ioservice,
+                      const std::string& logging_prefix) :
+        m_ioservice(ioservice)
+    {
+        m_logger = std::make_shared<logging_service_t>(
+                       "logging",
+                       m_ioservice,
+                       endpoint_t("127.0.0.1", 10053),
+                       std::shared_ptr<logging_service_t>(),
+                       logging_prefix
+                   );
+    }
+
+    template<class Service, typename... Args>
+    std::shared_ptr<Service>
+    get_service(const std::string& name,
+                Args&&... args)
+    {
+        auto new_service = std::make_shared<Service>(name,
+                                                     m_ioservice,
+                                                     endpoint_t("127.0.0.1", 10053),
+                                                     m_logger,
+                                                     std::forward<Args>(args)...);
+        new_service->initialize();
+        return new_service;
+    }
+
+    std::shared_ptr<logger_t>
+    get_system_logger() {
+        return m_logger;
+    }
+
+private:
+    cocaine::io::reactor_t& m_ioservice;
+
+    std::shared_ptr<logging_service_t> m_logger;
+};
+
+}} // cocaine::framework
+
+#endif // COCAINE_FRAMEWORK_SERVICE_MANAGER_HPP

--- a/include/cocaine/framework/services/logger.hpp
+++ b/include/cocaine/framework/services/logger.hpp
@@ -1,0 +1,58 @@
+#ifndef COCAINE_FRAMEWORK_SERVICES_LOGGING_HPP
+#define COCAINE_FRAMEWORK_SERVICES_LOGGING_HPP
+
+#include <cocaine/framework/service.hpp>
+#include <cocaine/framework/logging.hpp>
+
+namespace cocaine { namespace framework {
+
+class logging_service_t :
+    public std::enable_shared_from_this<logging_service_t>,
+    public service_t,
+    public logger_t
+{
+public:
+    logging_service_t(const std::string& name,
+                      cocaine::io::reactor_t& service,
+                      const cocaine::io::tcp::endpoint& resolver,
+                      std::shared_ptr<logger_t> logger, // not so much OMG
+                      const std::string& source) :
+        service_t(name,
+                  service,
+                  resolver,
+                  logger,
+                  cocaine::io::protocol<cocaine::io::logging_tag>::version::value),
+        m_priority(cocaine::logging::priorities::warning),
+        m_source(source)
+    {
+        // pass
+    }
+
+    void
+    emit(cocaine::logging::priorities priority,
+         const std::string& message)
+    {
+        call<cocaine::io::logging::emit>(priority, m_source, message);
+    }
+
+    cocaine::logging::priorities
+    verbosity() const {
+        return m_priority;
+    }
+
+    void
+    initialize();
+
+protected:
+    void
+    on_verbosity_response(cocaine::io::reactor_t *ioservice,
+                          const cocaine::io::message_t& message);
+
+private:
+    cocaine::logging::priorities m_priority;
+    std::string m_source;
+};
+
+}} // cocaine::framework
+
+#endif // COCAINE_FRAMEWORK_SERVICES_LOGGING_HPP

--- a/include/cocaine/framework/worker.hpp
+++ b/include/cocaine/framework/worker.hpp
@@ -3,7 +3,7 @@
 
 #include <cocaine/framework/basic_application.hpp>
 #include <cocaine/framework/upstream.hpp>
-#include <cocaine/framework/service.hpp>
+#include <cocaine/framework/service_manager.hpp>
 
 #include <cocaine/asio/local.hpp>
 #include <cocaine/asio/reactor.hpp>
@@ -84,7 +84,7 @@ private:
     std::string m_app_name;
     std::shared_ptr<basic_application_t> m_application;
 
-    std::shared_ptr<logging_service_t> m_log;
+    std::shared_ptr<logger_t> m_log;
 
     stream_map_t m_streams;
 };

--- a/src/service.cpp
+++ b/src/service.cpp
@@ -8,7 +8,7 @@ using namespace cocaine::framework;
 service_t::service_t(const std::string& name,
                      cocaine::io::reactor_t& ioservice,
                      const cocaine::io::tcp::endpoint& resolver_endpoint,
-                     std::shared_ptr<logging_service_t> logger,
+                     std::shared_ptr<logger_t> logger,
                      unsigned int version) :
     m_name(name),
     m_version(version),

--- a/src/services/logger.cpp
+++ b/src/services/logger.cpp
@@ -1,4 +1,4 @@
-#include <cocaine/framework/service.hpp>
+#include <cocaine/framework/services/logger.hpp>
 
 using namespace cocaine::framework;
 


### PR DESCRIPTION
Code that works with system logger can now also work with any other logger implementing this interface. It makes it easier to write code shared between Cocaine applications and something else (e.g. tools) that can be used without worker and service manager.
