### PR TITLE
Hold logger by base type instead of derived, to avoid needless upcasts

### DIFF
--- a/include/cocaine/framework/service_manager.hpp
+++ b/include/cocaine/framework/service_manager.hpp
@@ -24,7 +24,7 @@ public:
                        logging_prefix
                    );
 
-        m_logger->initialize();
+        std::static_pointer_cast<logging_service_t>(m_logger)->initialize();
     }
 
     template<class Service, typename... Args>
@@ -49,7 +49,7 @@ public:
 private:
     cocaine::io::reactor_t& m_ioservice;
 
-    std::shared_ptr<logging_service_t> m_logger;
+    std::shared_ptr<logger_t> m_logger;
 };
 
 }} // cocaine::framework


### PR DESCRIPTION
Specific type logger_service_t needed only to call initialize() method at service_manager's construction time. All further uses mean and require base type logger_t only. So it's more accurate to hold logger by base type and downcast it to logger_service_t once.

Also this change fixed error resulting in get_system_logger() returning shared_ptr<logger_t> that holds invalid (zero) raw pointer in my builds (precise, g++ 4.6).
