### PR TITLE
Make deprecation adapters usable.

### DIFF
--- a/include/cocaine/framework/application.hpp
+++ b/include/cocaine/framework/application.hpp
@@ -208,8 +208,7 @@ application<App>::on(const std::string& event,
         std::bind(method,
                   this->shared_from_this(),
                   std::placeholders::_1,
-                  std::placeholders::_2,
-                  std::placeholders::_3)
+                  std::placeholders::_2)
     )));
 }
 
@@ -233,8 +232,7 @@ application<App>::on_unregistered(
         std::bind(method,
                   this->shared_from_this(),
                   std::placeholders::_1,
-                  std::placeholders::_2,
-                  std::placeholders::_3)
+                  std::placeholders::_2)
     )));
 }
 


### PR DESCRIPTION
Deprecation adapters are unusable because they try to bind the old binary functions with three placeholders. Removed an extra placeholder so that this binding might work as intended.
