### PR TITLE
Fixed string literal forwarding

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+cocaine-framework-native (0.12.3-1) unstable; urgency=low
+
+  * Minor: fixed string literal forwarding.
+    Now it's possible to use string literals in service and channels API
+    instead of wrapping them into `std::string`.
+
+ -- Evgeny Safronov <division494@gmail.com>  Wed, 12 Aug 2015 10:13:06 +0300
+
 cocaine-framework-native (0.12.3-0) unstable; urgency=low
 
   * Debian: fix dependencies from Node plugin.

--- a/example/client/main.cpp
+++ b/example/client/main.cpp
@@ -41,7 +41,7 @@ on_invoke(task<channel<io::app::enqueue>>::future_move_type future) {
     auto channel = future.get();
     auto tx = std::move(channel.tx);
     auto rx = std::move(channel.rx);
-    return tx.send<scope::chunk>(std::string("le message"))
+    return tx.send<scope::chunk>("le message")
         .then(trace_t::bind(&on_send, std::placeholders::_1, rx))
         .then(trace_t::bind(&on_chunk, std::placeholders::_1, rx))
         .then(trace_t::bind(&on_choke, std::placeholders::_1));
@@ -71,7 +71,7 @@ int main(int argc, char** argv) {
 
         for (uint id = 0; id < iters; ++id) {
             futures.emplace_back(
-                    echo.invoke<cocaine::io::app::enqueue>(std::string(event))
+                    echo.invoke<cocaine::io::app::enqueue>(event)
                 .then(trace_t::bind(&app::on_invoke, std::placeholders::_1))
                 .then(trace_t::bind(&app::on_finalize, std::placeholders::_1))
             );

--- a/include/cocaine/framework/service.hpp
+++ b/include/cocaine/framework/service.hpp
@@ -95,7 +95,7 @@ public:
         trace::context_holder holder("SI");
 
         return connect()
-            .then(scheduler, trace::wrap(trace_t::bind(&basic_service_t::on_connect<Event, Args...>, ph::_1, session, std::forward<Args>(args)...)))
+            .then(scheduler, trace::wrap(trace_t::bind(&basic_service_t::on_connect<Event, typename std::decay<Args>::type...>, ph::_1, session, std::forward<Args>(args)...)))
             .then(scheduler, trace::wrap(trace_t::bind(&basic_service_t::on_invoke<Event>, ph::_1)));
     }
 
@@ -131,4 +131,3 @@ public:
 };
 
 }} // namespace cocaine::framework
-

--- a/tst/func/manual/service.cpp
+++ b/tst/func/manual/service.cpp
@@ -12,12 +12,12 @@ using namespace cocaine::framework;
 TEST(manual, DISABLED_StorageAutoReconnect) {
     service_manager_t manager(1);
     auto storage = manager.create<cocaine::io::storage_tag>("storage");
-    auto result = storage.invoke<cocaine::io::storage::read>(std::string("collection"), std::string("key")).get();
+    auto result = storage.invoke<cocaine::io::storage::read>("collection", "key").get();
 
     EXPECT_EQ("le value", result);
     sleep(5);
 
-    result = storage.invoke<cocaine::io::storage::read>(std::string("collection"), std::string("key")).get();
+    result = storage.invoke<cocaine::io::storage::read>("collection", "key").get();
 
     EXPECT_EQ("le value", result);
 }

--- a/tst/func/real/logging.cpp
+++ b/tst/func/real/logging.cpp
@@ -18,12 +18,12 @@ using namespace cocaine::framework;
 TEST(service, Logging) {
     service_manager_t manager(1);
     auto logger = manager.create<io::log_tag>("logging");
-    logger.invoke<io::log::emit>(logging::info, std::string("app/testing"), std::string("le message")).get();
+    logger.invoke<io::log::emit>(logging::info, "app/testing", "le message").get();
 
     logger.invoke<io::log::emit>(
         logging::info,
-        std::string("app/testing"),
-        std::string("le message"),
+        "app/testing",
+        "le message",
         blackhole::attribute::set_t({{ "key", blackhole::attribute::value_t(42) }})
     ).get();
 }

--- a/tst/func/real/service.cpp
+++ b/tst/func/real/service.cpp
@@ -65,7 +65,7 @@ TEST(service, VersionMismatch) {
 TEST(service, Storage) {
     service_manager_t manager(1);
     auto storage = manager.create<cocaine::io::storage_tag>("storage");
-    auto result = storage.invoke<cocaine::io::storage::read>(std::string("collection"), std::string("key")).get();
+    auto result = storage.invoke<cocaine::io::storage::read>("collection", "key").get();
 
     EXPECT_EQ("le value", result);
 }
@@ -74,7 +74,7 @@ TEST(service, StorageError) {
     service_manager_t manager(1);
     auto storage = manager.create<cocaine::io::storage_tag>("storage");
 
-    EXPECT_THROW(storage.invoke<cocaine::io::storage::read>(std::string("i-collection"), std::string("key")).get(), response_error);
+    EXPECT_THROW(storage.invoke<cocaine::io::storage::read>("i-collection", "key").get(), response_error);
 }
 
 TEST(service, Echo) {
@@ -83,11 +83,11 @@ TEST(service, Echo) {
     service_manager_t manager(1);
     auto echo = manager.create<cocaine::io::storage_tag>("echo-cpp");
 
-    auto channel = echo.invoke<cocaine::io::app::enqueue>(std::string("ping")).get();
+    auto channel = echo.invoke<cocaine::io::app::enqueue>("ping").get();
     auto tx = std::move(channel.tx);
     auto rx = std::move(channel.rx);
 
-    tx.send<upstream::chunk>(std::string("le message")).get()
+    tx.send<upstream::chunk>("le message").get()
         .send<upstream::choke>().get();
     auto result = rx.recv().get();
 
@@ -131,7 +131,7 @@ on_invoke(task<invocation_result<cocaine::io::app::enqueue>::type>::future_move_
     auto channel = future.get();
     auto tx = std::move(channel.tx);
     auto rx = std::move(channel.rx);
-    return tx.send<upstream::chunk>(std::string("le message"))
+    return tx.send<upstream::chunk>("le message")
         .then(std::bind(&on_send, ph::_1, rx))
         .then(std::bind(&on_recv, ph::_1, rx))
         .then(std::bind(&on_choke, ph::_1));
@@ -143,7 +143,7 @@ TEST(service, EchoAsynchronous) {
     service_manager_t manager(1);
     auto echo = manager.create<cocaine::io::storage_tag>("echo-cpp");
 
-    echo.invoke<cocaine::io::app::enqueue>(std::string("ping"))
+    echo.invoke<cocaine::io::app::enqueue>("ping")
         .then(std::bind(&on_invoke, ph::_1))
         .get();
 }

--- a/tst/load/app/echo.cpp
+++ b/tst/load/app/echo.cpp
@@ -54,7 +54,7 @@ future<void>
 on_invoke(future<channel<io::app::enqueue>>& fr) {
     auto channel = fr.get();
 
-    channel.tx.send<scope::chunk>(std::string("le message"))
+    channel.tx.send<scope::chunk>("le message")
         .then([](future<framework::channel<io::app::enqueue>::sender_type>& fr2)
     {
         auto tx = fr2.get();
@@ -91,7 +91,7 @@ TEST(load, app_echo) {
         load_context context(id, counter, stats.stats);
 
         futures.emplace_back(
-            echo.invoke<io::app::enqueue>(std::string(event))
+            echo.invoke<io::app::enqueue>(event)
                 .then(std::bind(&app::echo::on_invoke, ph::_1))
                 .then(std::bind(&finalize, ph::_1, std::move(context)))
         );
@@ -152,7 +152,7 @@ TEST(load, app_version) {
         load_context context(id, counter, stats.stats);
 
         futures.emplace_back(
-            echo.invoke<io::app::enqueue>(std::string(event))
+            echo.invoke<io::app::enqueue>(event)
                 .then(std::bind(&app::echo::version::on_invoke, ph::_1))
                 .then(std::bind(&finalize, ph::_1, std::move(context)))
         );

--- a/tst/load/service/echo.cpp
+++ b/tst/load/service/echo.cpp
@@ -49,7 +49,7 @@ TEST(load, service_echo) {
         load_context context(id, counter, stats.stats);
 
         futures.emplace_back(
-            echo.invoke<io::echo::ping>(std::string("le message"))
+            echo.invoke<io::echo::ping>("le message")
                 .then(std::bind(&load::service::echo::on_invoke, ph::_1))
                 .then(std::bind(&finalize, ph::_1, context))
         );
@@ -84,7 +84,7 @@ TEST(load, service_echo_with_timeout) {
         load_context context(id, counter, stats.stats);
 
         futures.emplace_back(
-            echo.invoke<io::echo::ping_with_timeout>(std::string("le message"), 100)
+            echo.invoke<io::echo::ping_with_timeout>("le message", 100)
                 .then(std::bind(&load::service::echo::on_invoke, ph::_1))
                 .then(std::bind(&finalize, ph::_1, context))
         );

--- a/tst/load/service/storage.cpp
+++ b/tst/load/service/storage.cpp
@@ -47,7 +47,7 @@ TEST(load, service_storage) {
         load_context context(id, counter, stats.stats);
 
         futures.emplace_back(
-            storage.invoke<io::storage::read>(std::string("collection"), std::string("key"))
+            storage.invoke<io::storage::read>("collection", "key")
                 .then(std::bind(&load::service::storage::on_invoke, ph::_1))
                 .then(std::bind(&finalize, ph::_1, std::ref(context)))
         );
@@ -60,5 +60,3 @@ TEST(load, service_storage) {
 
     EXPECT_EQ(iters, counter);
 }
-
-


### PR DESCRIPTION
Now it's possible to use string literals in services and channels API instead of wrapping them with `std::string`.

```c++
// Before:
auto result = storage.invoke<io::storage::read>(std::string("collection"), std::string("key")).get();
// After:
auto result = storage.invoke<io::storage::read>("collection", "key").get();
```
