### PR TITLE
Hide foreign symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,9 @@ TARGET_LINK_LIBRARIES(cocaine-framework
 
 SET_TARGET_PROPERTIES(cocaine-framework PROPERTIES
     VERSION 1
-    COMPILE_FLAGS "-std=c++0x -W -Wall -Werror -pedantic")
+    COMPILE_FLAGS "-std=c++0x -W -Wall -Werror -pedantic"
+    LINK_FLAGS "-Wl,--version-script=${PROJECT_SOURCE_DIR}/libcocaine-framework.version"
+)
 
 IF(NOT COCAINE_LIBDIR)
     SET(COCAINE_LIBDIR lib)

--- a/libcocaine-framework.version
+++ b/libcocaine-framework.version
@@ -1,0 +1,5 @@
+{
+    global: _ZN7cocaine9framework*; _ZTI*; _ZTS*; _ZTN*; _ZNK*;
+    local: *;
+};
+


### PR DESCRIPTION
Hide all symbols except those from cocaine::framework namespace (which constitute public library interface) and typeinfo stuff.

Most important result is concealment of boost::asio symbols.