### PR TITLE
functonal: implement virtual destructor

### DIFF
--- a/include/cocaine/framework/handlers/functional.hpp
+++ b/include/cocaine/framework/handlers/functional.hpp
@@ -42,6 +42,7 @@ public:
             function_type_t;
 
     function_handler_t(function_type_t f);
+    virtual ~function_handler_t();
 
     void
     on_chunk(const char *chunk,

--- a/src/handlers/functional.cpp
+++ b/src/handlers/functional.cpp
@@ -28,6 +28,10 @@ function_handler_t::function_handler_t(function_handler_t::function_type_t f) :
     // pass
 }
 
+function_handler_t::~function_handler_t()
+{
+}
+
 void
 function_handler_t::on_chunk(const char *chunk,
                              size_t size)


### PR DESCRIPTION
This fixes 'Undefined reference to vtable' error on g++ 5.3.1 which is needed to build elliptics on Ubuntu Xenial