### PR TITLE
Updated cocaine-framework-native to compile with gcc6

### DIFF
--- a/cocaine-framework-native-bf.spec
+++ b/cocaine-framework-native-bf.spec
@@ -11,12 +11,17 @@ BuildRoot:  %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:  boost-devel
 BuildRequires:  libev-devel
-BuildRequires:  msgpack-devel
 BuildRequires:  libcocaine-core2-devel
 %if %{defined rhel} && 0%{?rhel} < 7
 BuildRequires:  cmake28
 %else
 BuildRequires:  cmake
+%endif
+
+%if 0%{?fedora} >= 24
+Requires: compat-msgpack-devel
+%else
+Requires: msgpack-devel
 %endif
 
 %description

--- a/cocaine-framework-native-bf.spec
+++ b/cocaine-framework-native-bf.spec
@@ -19,9 +19,9 @@ BuildRequires:  cmake
 %endif
 
 %if 0%{?fedora} >= 24
-Requires: compat-msgpack-devel
+BuildRequires: compat-msgpack-devel
 %else
-Requires: msgpack-devel
+BuildRequires: msgpack-devel
 %endif
 
 %description

--- a/include/cocaine/framework/common.hpp
+++ b/include/cocaine/framework/common.hpp
@@ -31,7 +31,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 #include <exception>
 #include <utility>
 
-#if defined(__clang__) || defined(HAVE_GCC46)
+#if defined(__clang__) || defined(HAVE_GCC46) || __GNUC__ >= 5
     #include <atomic>
 #else
     #include <cstdatomic>


### PR DESCRIPTION
If merge, please update package version